### PR TITLE
2877 - add Setting up env variable on Azure Devops Pipeline video to the Infra page

### DIFF
--- a/docs/infrastructure/azure/pipelines/azure_devops.md
+++ b/docs/infrastructure/azure/pipelines/azure_devops.md
@@ -12,6 +12,7 @@ keywords:
 
 import HideNavigation  from "../../../../src/pages/HideNavigation";
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import ResponsivePlayer from "../../../../src/pages/Components/ResponsivePlayer/ResponsivePlayer";
 
 The pipeline will automate provisioning and updating the core infrastructure in Azure. This page assumes you have already completed the steps on the [core infrastructure page](../core_infrastructure.md).
 
@@ -47,6 +48,7 @@ resources:
 
 Variable groups will need creating for storing Azure Credentials to be used with the pipeline. Instructions for creating a variable group can be found [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/variable-groups?view=azure-devops&tabs=classic#create-a-variable-group).
 
+<ResponsivePlayer url="https://youtu.be/PKOFParEhFI" />
 Create a variable group for the nonprod infrastructure. Give the variable group a name and description and make sure the **Allow access to all pipelines** option is checked. Add the following variables using the Service Connection details from [bootstrapping the Azure tenant](../core_infrastructure.md#bootstrap-the-azure-tenant):
 
 * azure_tenant_id


### PR DESCRIPTION
<!--
2877 - add Setting up env variable on Azure Devops Pipeline video to the Infra page
[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

2877 - add Setting up env variable on Azure Devops Pipeline video to the Infra page

<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message, 
e.g. Implements `[AB#1228](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1228) - Link tickets to GitHub`
-->

#### 🤔 Why
		
Why it's needed, background context.
		
#### 🛠 How
		
More in-depth discussion of the change or implementation.

#### 👀 Evidence
		
Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR.
		 
#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
