### PR TITLE
docs: Document starting the Java Application MacOS - 3621

### DIFF
--- a/docs/workloads/azure/backend/java/setting_up_cosmos_db_locally_java.md
+++ b/docs/workloads/azure/backend/java/setting_up_cosmos_db_locally_java.md
@@ -131,36 +131,22 @@ keytool -list -keystore cacerts
 </TabItem>
 <TabItem value="unix">
 
-In order to allow the Java Application to connect to the **CosmosDB Emulator**, you need to import its self-signed
-certificate to a java trust store.
-
 #### Download the certificate
+
 ```bash
 curl -k https://localhost:8081/_explorer/emulator.pem > emulatorcert.crt
 ```
 
-#### Import the certificate to a trust store
+#### Import to Java trust store
+
 ```bash
-keytool -keystore "<path to keystore>" \
-  -importcert \
-  -alias documentdbemulator \
-  -file "<path to emulatorcert.crt>"
+keytool -importcert -cacerts -alias documentdbemulator -file <path to emulatorcert.crt>
 ```
 
-At this point the certificate is imported but Java is unable to use it, as it uses a format that is unsupported
-in Java 11. The trust store needs to be converted from [`pkcs12` (SSL)](https://en.wikipedia.org/wiki/PKCS_12) to
-[`jks` (Java KeyStore)](https://en.wikipedia.org/wiki/Java_KeyStore).
+In order to make sure the certificate is there, you can run the following:
 
-#### Convert the trust store
 ```bash
-keytool -importkeystore \
-  -srckeystore "<path to the trust store>" \
-  -srcstoretype pkcs12 \
-  -srcalias documentdbemulator \
-  -destkeystore "<path to the converted trust store>" \
-  -deststoretype jks \
-  -deststorepass "<store password>" \
-  -destalias documentdbemulator
+keytool -list -cacerts | grep -A1 documentdbemulator
 ```
 
 </TabItem>

--- a/docs/workloads/azure/backend/java/setting_up_cosmos_db_locally_java.md
+++ b/docs/workloads/azure/backend/java/setting_up_cosmos_db_locally_java.md
@@ -128,6 +128,7 @@ Now running the below should list 4 certificates.
 ```bash
 keytool -list -keystore cacerts
 ```
+
 </TabItem>
 <TabItem value="unix">
 

--- a/docs/workloads/azure/backend/java/setting_up_cosmos_db_locally_java.md
+++ b/docs/workloads/azure/backend/java/setting_up_cosmos_db_locally_java.md
@@ -13,93 +13,156 @@ keywords:
   - certificate
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Set up Cosmos DB Emulator locally
 
-The Azure Cosmos emulator provides a local environment that emulates the Azure Cosmos DB
-service for development purposes. Using the Azure Cosmos emulator, you can develop and test
+The Azure CosmosDB Emulator provides a local environment that emulates the Azure Cosmos DB
+service for development purposes. Using the Azure CosmosDB Emulator, you can develop and test
 your application locally, without creating an Azure subscription or incurring any costs.
 Latest instruction can be found in [here](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator?tabs=cli%2Cssl-netstd21)
 
 ### Using the Cosmos DB Emulator to run the database locally
 
-   Download and install the latest version of CosmosDB Emulator. Once it's installed it will be
-   available on [localhost](https://localhost:8081/_explorer/index.html)
+Download and install the latest version of **CosmosDB Emulator**. Once it's installed, it will be
+available on [localhost](https://localhost:8081/_explorer/index.html).
 
-   You can also find the Emulator from Start Menu and type Azure Cosmos DB Emulator.
-   The value for **COSMOSDB_KEY** can be found within the emulator. See Primary Key:
+<Tabs
+    groupId="operating-systems"
+    defaultValue="unix"
+    values={[
+    { label: 'Unix', value: 'unix'},
+    { label: 'Windows', value: 'windows'}
+]}>
+<TabItem value="windows">
+You can also find the Emulator from Start Menu and type Azure CosmosDB Emulator.
+</TabItem>
+<TabItem value="unix">
 
-   ![cosmosdb](/img/cosmosdb_emulator_3.png)
-   Set the cosmosdb URI, databaseName and key in application.yml file using the value above
+The **CosmosDB Emulator** service is primarily a Windows service, so using it in Unix/Linux/MacOS requires a few
+additional steps. One of the simplest ways of running the emulator is to download
+the [Linux Emulator](https://docs.microsoft.com/en-us/azure/cosmos-db/linux-emulator) for Docker.
+Please follow the installation instructions, with one exception: when running the Docker image, don't set
+the `AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE=$ipaddr`. Instead, set it to `127.0.0.1`.
 
-   ```yaml
-   azure:
-     cosmosdb:
-       uri: xxxxxx
-       database: xxxxxx
-       key: xxxxxx
-   ```
+</TabItem>
+</Tabs>
 
-<br />
+The value for `COSMOSDB_KEY` can be found within the emulator. See Primary Key:
+
+![cosmosdb](/img/cosmosdb_emulator_3.png)
+Set the cosmosdb URI, databaseName and key in `application.yml` file using the value above
+
+```yaml
+azure:
+ cosmosdb:
+   uri: xxxxxx
+   database: xxxxxx
+   key: xxxxxx
+```
 
 ### Create the Cosmos DB structure
 
-  Based on the template the Cosmos DB has to contain a fixed structure.
+Based on the template the CosmosDB has to contain a fixed structure.
 
-  Create a collection **Stacks** with a container id **menu** and the partition key **/id**.
+Create a collection **Stacks** with a container id **menu** and the partition key **/id**.
 
-  Create a database called Stacks for the application, and a database called CosmosDBPackage for the
-  integration tests of the CosmosDB package
+Create a database called Stacks for the application, and a database called CosmosDBPackage for the
+integration tests of the CosmosDB package
 
-  ![cosmosdb](/img/cosmosdb_emulator_1.png)
+![cosmosdb](/img/cosmosdb_emulator_1.png)
 
 <br />
 
-  The **Stacks** database should have a container called **Menu** partitioned by **/id**.
+The **Stacks** database should have a container called **Menu** partitioned by **/id**.
 
-  ![cosmosdb](/img/cosmosdb_emulator_2.png)
+![cosmosdb](/img/cosmosdb_emulator_2.png)
 
-  <br />
+<br />
 
 ### Export Azure Cosmos DB Emulator certificates to use in the Java Application
 
-  Start the Windows Certificate manager by running certlm.msc and navigate to the Personal->Certificates folder and open the certificate with the friendly name DocumentDbEmulatorCertificate.
+<Tabs
+groupId="operating-systems"
+defaultValue="unix"
+values={[
+{ label: 'Unix', value: 'unix'},
+{ label: 'Windows', value: 'windows'}
+]}>
+<TabItem value="windows">
+Start the Windows Certificate manager by running certlm.msc and navigate to the Personal->Certificates folder and open the certificate with the friendly name DocumentDbEmulatorCertificate.
 
-  <br />
+![certificates](/img/cosmosdb_emulator_certificate.png)
 
-  ![certificates](/img/cosmosdb_emulator_certificate.png)
+Follow the steps in [Export the Azure Cosmos DB TLS/SSL certificate](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator-export-ssl-certificates#export-emulator-certificate)
+Also Export CosmosEmulatorSecretes following the above link.
 
-  <br />
-
-  Follow the steps in [Export the Azure Cosmos DB TLS/SSL certificate](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator-export-ssl-certificates#export-emulator-certificate)
-  Also Export CosmosEmulatorSecretes following the above link.
-  
 ### Determine which root certificates have been installed
 
-   Follow the steps to determine which root certificates have been installed [Add Root certificate](https://docs.microsoft.com/en-us/azure/developer/java/sdk/java-sdk-add-certificate-ca-store#determining-which-root-certificates-are-installed)
+Follow the steps to determine which root certificates have been installed [Add Root certificate](https://docs.microsoft.com/en-us/azure/developer/java/sdk/java-sdk-add-certificate-ca-store#determining-which-root-certificates-are-installed)
 
-   Now import the documentdbemulatorcert and CosmosEmulatorSecrets certificate.
+Now import the documentdbemulatorcert and CosmosEmulatorSecrets certificate.
 
-   ```bash
-   keytool -keystore "location to download the root certificate" -cacerts -importcert -alias documentdbemulator -file "location of documentdbemulatorcert.cer"
-   ```
+```bash
+keytool -keystore "location to download the root certificate" -cacerts -importcert -alias documentdbemulator -file "location of documentdbemulatorcert.cer"
+```
 
-   type the password when prompted "changeit" (This should be the same if you haven't changed it when listing the certificates).
-   If asked "do you trust this certificate" type in "y".
+type the password when prompted "changeit" (This should be the same if you haven't changed it when listing the certificates).
+If asked "do you trust this certificate" type in "y".
 
-   follow the above steps to import cosmosemulatorsecrets certificate
+follow the above steps to import cosmosemulatorsecrets certificate
 
-   ```bash
-   keytool -keystore "location to download the root certificate" -cacerts -importcert -alias cosmosemulatorcert -file "location of cosmosemulatorsecrets.cer"
-   ```
+```bash
+keytool -keystore "location to download the root certificate" -cacerts -importcert -alias cosmosemulatorcert -file "location of cosmosemulatorsecrets.cer"
+```
 
-   Go to URL in your browser:
+Go to URL in your browser:
 
-   **Firefox** --  click on HTTPS certificate chain (the lock icon right next to URL address). Click "more info" > "security" > "show certificate" > "details" > "export..". Pickup the name and choose file type example.cer.
+**Firefox** -- click on HTTPS certificate chain (the lock icon right next to URL address). Click "more info" > "security" > "show certificate" > "details" > "export..". Pickup the name and choose file type example.cer.
 
-   **Chrome**  -- click on site icon left to address in address bar, select "Certificate" -> "Details" -> "Export" and save in format "Der-encoded binary, single certificate".
+**Chrome**  -- click on site icon left to address in address bar, select "Certificate" -> "Details" -> "Export" and save in format "Der-encoded binary, single certificate".
 
-   Now running the below should list 4 certificates.
+Now running the below should list 4 certificates.
 
-   ```bash
-   keytool -list -keystore cacerts
-   ```
+```bash
+keytool -list -keystore cacerts
+```
+</TabItem>
+<TabItem value="unix">
+
+In order to allow the Java Application to connect to the **CosmosDB Emulator**, you need to import its self-signed
+certificate to a java trust store.
+
+#### Download the certificate
+```bash
+curl -k https://localhost:8081/_explorer/emulator.pem > emulatorcert.crt
+```
+
+#### Import the certificate to a trust store
+```bash
+keytool -keystore "<path to keystore>" \
+  -importcert \
+  -alias documentdbemulator \
+  -file "<path to emulatorcert.crt>"
+```
+
+At this point the certificate is imported but Java is unable to use it, as it uses a format that is unsupported
+in Java 11. The trust store needs to be converted from [`pkcs12` (SSL)](https://en.wikipedia.org/wiki/PKCS_12) to
+[`jks` (Java KeyStore)](https://en.wikipedia.org/wiki/Java_KeyStore).
+
+#### Convert the trust store
+```bash
+keytool -importkeystore \
+  -srckeystore "<path to the trust store>" \
+  -srcstoretype pkcs12 \
+  -srcalias documentdbemulator \
+  -destkeystore "<path to the converted trust store>" \
+  -deststoretype jks \
+  -deststorepass "<store password>" \
+  -destalias documentdbemulator
+```
+
+</TabItem>
+</Tabs>
+

--- a/docs/workloads/azure/backend/java_cqrs/setting_up_cosmos_db_locally_java_cqrs.md
+++ b/docs/workloads/azure/backend/java_cqrs/setting_up_cosmos_db_locally_java_cqrs.md
@@ -128,6 +128,7 @@ Now running the below should list 4 certificates.
 ```bash
 keytool -list -keystore cacerts
 ```
+
 </TabItem>
 <TabItem value="unix">
 

--- a/docs/workloads/azure/backend/java_cqrs/setting_up_cosmos_db_locally_java_cqrs.md
+++ b/docs/workloads/azure/backend/java_cqrs/setting_up_cosmos_db_locally_java_cqrs.md
@@ -13,93 +13,142 @@ keywords:
   - certificate
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Set up Cosmos DB Emulator locally
 
-The Azure Cosmos emulator provides a local environment that emulates the Azure Cosmos DB
-service for development purposes. Using the Azure Cosmos emulator, you can develop and test
+The Azure CosmosDB Emulator provides a local environment that emulates the Azure Cosmos DB
+service for development purposes. Using the Azure CosmosDB Emulator, you can develop and test
 your application locally, without creating an Azure subscription or incurring any costs.
 Latest instruction can be found in [here](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator?tabs=cli%2Cssl-netstd21)
 
 ### Using the Cosmos DB Emulator to run the database locally
 
-   Download and install the latest version of CosmosDB Emulator. Once it's installed it will be
-   available on [localhost](https://localhost:8081/_explorer/index.html)
+Download and install the latest version of **CosmosDB Emulator**. Once it's installed, it will be
+available on [localhost](https://localhost:8081/_explorer/index.html).
 
-   You can also find the Emulator from Start Menu and type Azure Cosmos DB Emulator.
-   The value for **COSMOSDB_KEY** can be found within the emulator. See Primary Key:
+<Tabs
+groupId="operating-systems"
+defaultValue="unix"
+values={[
+{ label: 'Unix', value: 'unix'},
+{ label: 'Windows', value: 'windows'}
+]}>
+<TabItem value="windows">
+You can also find the Emulator from Start Menu and type Azure CosmosDB Emulator.
+</TabItem>
+<TabItem value="unix">
 
-   ![cosmosdb](/img/cosmosdb_emulator_3.png)
-   Set the cosmosdb URI, databaseName and key in application.yml file using the value above
+The **CosmosDB Emulator** service is primarily a Windows service, so using it in Unix/Linux/MacOS requires a few
+additional steps. One of the simplest ways of running the emulator is to download
+the [Linux Emulator](https://docs.microsoft.com/en-us/azure/cosmos-db/linux-emulator) for Docker.
+Please follow the installation instructions, with one exception: when running the Docker image, don't set
+the `AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE=$ipaddr`. Instead, set it to `127.0.0.1`.
 
-   ```yaml
-   azure:
-     cosmosdb:
-       uri: xxxxxx
-       database: xxxxxx
-       key: xxxxxx
-   ```
+</TabItem>
+</Tabs>
 
-<br />
+The value for `COSMOSDB_KEY` can be found within the emulator. See Primary Key:
+
+![cosmosdb](/img/cosmosdb_emulator_3.png)
+Set the cosmosdb URI, databaseName and key in `application.yml` file using the value above
+
+```yaml
+azure:
+ cosmosdb:
+   uri: xxxxxx
+   database: xxxxxx
+   key: xxxxxx
+```
 
 ### Create the Cosmos DB structure
 
-  Based on the template the Cosmos DB has to contain a fixed structure.
+Based on the template the CosmosDB has to contain a fixed structure.
 
-  Create a collection **Stacks** with a container id **menu** and the partition key **/id**.
+Create a collection **Stacks** with a container id **menu** and the partition key **/id**.
 
-  Create a database called Stacks for the application, and a database called CosmosDBPackage for the
-  integration tests of the CosmosDB package
+Create a database called Stacks for the application, and a database called CosmosDBPackage for the
+integration tests of the CosmosDB package
 
-  ![cosmosdb](/img/cosmosdb_emulator_1.png)
+![cosmosdb](/img/cosmosdb_emulator_1.png)
 
 <br />
 
-  The **Stacks** database should have a container called **Menu** partitioned by **/id**.
+The **Stacks** database should have a container called **Menu** partitioned by **/id**.
 
-  ![cosmosdb](/img/cosmosdb_emulator_2.png)
+![cosmosdb](/img/cosmosdb_emulator_2.png)
 
-  <br />
+<br />
 
 ### Export Azure Cosmos DB Emulator certificates to use in the Java Application
 
-  Start the Windows Certificate manager by running certlm.msc and navigate to the Personal->Certificates folder and open the certificate with the friendly name DocumentDbEmulatorCertificate.
+<Tabs
+groupId="operating-systems"
+defaultValue="unix"
+values={[
+{ label: 'Unix', value: 'unix'},
+{ label: 'Windows', value: 'windows'}
+]}>
+<TabItem value="windows">
+Start the Windows Certificate manager by running certlm.msc and navigate to the Personal->Certificates folder and open the certificate with the friendly name DocumentDbEmulatorCertificate.
 
-  <br />
+![certificates](/img/cosmosdb_emulator_certificate.png)
 
-  ![certificates](/img/cosmosdb_emulator_certificate.png)
+Follow the steps in [Export the Azure Cosmos DB TLS/SSL certificate](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator-export-ssl-certificates#export-emulator-certificate)
+Also Export CosmosEmulatorSecretes following the above link.
 
-  <br />
-
-  Follow the steps in [Export the Azure Cosmos DB TLS/SSL certificate](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator-export-ssl-certificates#export-emulator-certificate)
-  Also Export CosmosEmulatorSecretes following the above link.
-  
 ### Determine which root certificates have been installed
 
-   Follow the steps to determine which root certificates have been installed [Add Root certificate](https://docs.microsoft.com/en-us/azure/developer/java/sdk/java-sdk-add-certificate-ca-store#determining-which-root-certificates-are-installed)
+Follow the steps to determine which root certificates have been installed [Add Root certificate](https://docs.microsoft.com/en-us/azure/developer/java/sdk/java-sdk-add-certificate-ca-store#determining-which-root-certificates-are-installed)
 
-   Now import the documentdbemulatorcert and CosmosEmulatorSecrets certificate.
+Now import the documentdbemulatorcert and CosmosEmulatorSecrets certificate.
 
-   ```bash
-   keytool -keystore "location to download the root certificate" -cacerts -importcert -alias documentdbemulator -file "location of documentdbemulatorcert.cer"
-   ```
+```bash
+keytool -keystore "location to download the root certificate" -cacerts -importcert -alias documentdbemulator -file "location of documentdbemulatorcert.cer"
+```
 
-   type the password when prompted "changeit" (This should be the same if you haven't changed it when listing the certificates).
-   If asked "do you trust this certificate" type in "y".
+type the password when prompted "changeit" (This should be the same if you haven't changed it when listing the certificates).
+If asked "do you trust this certificate" type in "y".
 
-   follow the above steps to import cosmosemulatorsecrets certificate
+follow the above steps to import cosmosemulatorsecrets certificate
 
-   ```bash
-   keytool -keystore "location to download the root certificate" -cacerts -importcert -alias cosmosemulatorcert -file "location of cosmosemulatorsecrets.cer"
-   ```
+```bash
+keytool -keystore "location to download the root certificate" -cacerts -importcert -alias cosmosemulatorcert -file "location of cosmosemulatorsecrets.cer"
+```
 
-   Go to URL in your browser:
+Go to URL in your browser:
 
-   **Firefox** --  click on HTTPS certificate chain (the lock icon right next to URL address). Click "more info" > "security" > "show certificate" > "details" > "export..". Pickup the name and choose file type example.cer.
+**Firefox** -- click on HTTPS certificate chain (the lock icon right next to URL address). Click "more info" > "security" > "show certificate" > "details" > "export..". Pickup the name and choose file type example.cer.
 
-   **Chrome**  -- click on site icon left to address in address bar, select "Certificate" -> "Details" -> "Export" and save in format "Der-encoded binary, single certificate".
+**Chrome**  -- click on site icon left to address in address bar, select "Certificate" -> "Details" -> "Export" and save in format "Der-encoded binary, single certificate".
 
-   Now running the below should list 4 certificates.
+Now running the below should list 4 certificates.
 
-   ```bash
-   keytool -list -keystore cacerts
-   ```
+```bash
+keytool -list -keystore cacerts
+```
+</TabItem>
+<TabItem value="unix">
+
+#### Download the certificate
+
+```bash
+curl -k https://localhost:8081/_explorer/emulator.pem > emulatorcert.crt
+```
+
+#### Import to Java trust store
+
+```bash
+keytool -importcert -cacerts -alias documentdbemulator -file <path to emulatorcert.crt>
+```
+
+In order to make sure the certificate is there, you can run the following:
+
+```bash
+keytool -list -cacerts | grep -A1 documentdbemulator
+```
+
+</TabItem>
+</Tabs>
+


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 Document starting the Java app on MacOS

This change adds documentation describing the correct set-up of the CosmosDB Emulator in non-Windows environments.
This was tested only in MacOS.

#### 🤔 Why
		
I am the first developer to use a Macbook with MacOS and the currently existing documentation doesn't work for this OS.
		
#### 🛠 How
		
N/A

#### 👀 Evidence

N/A
		 
#### 🕵️ How to test

The only page changed is [Cosmos DB Emulator](https://stacks.amido.com/docs/workloads/azure/backend/java/setting_up_cosmos_db_locally_java)

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
