### PR TITLE
Replaced token with version number

### DIFF
--- a/docs/stackscli/usage.mdx
+++ b/docs/stackscli/usage.mdx
@@ -19,10 +19,10 @@ As the CLI is a single binary the quickest way to install it is to download it a
 ``` bash
 # Download the binary to a location in the PATH
 ## Mac OS
-wget https://github.com/amido/stacks-cli/releases/download/v{stackscli_version}/stacks-cli-darwin-amd64-{stackscli_version} -O /usr/local/bin/stacks-cli
+wget https://github.com/amido/stacks-cli/releases/download/v0.0.218/stacks-cli-darwin-amd64-0.0.218 -O /usr/local/bin/stacks-cli
 
 ## Linux
-wget https://github.com/amido/stacks-cli/releases/download/v{stackscli_version}/stacks-cli-linux-amd64-{stackscli_version} -O /usr/local/bin/stacks-cli
+wget https://github.com/amido/stacks-cli/releases/download/v0.0.218/stacks-cli-linux-amd64-0.0.218 -O /usr/local/bin/stacks-cli
 
 ## Ensure that the command is executable
 chmod +x /usr//local/bin/stacks-cli
@@ -34,7 +34,7 @@ The following PowerShell snippet will download the application to the user’s D
 
 ``` powershell
 # Download the binary
-Invoke-RestMethod -Uri https://github.com/amido/stacks-cli/releases/download/v{stackscli_version}/stacks-cli-windows-amd64-{stackscli_version}.exe -OutFile $env:USERPROFILE\Downloads\stacks-cli.exe
+Invoke-RestMethod -Uri https://github.com/amido/stacks-cli/releases/download/v0.0.218/stacks-cli-windows-amd64-0.0.218.exe -OutFile $env:USERPROFILE\Downloads\stacks-cli.exe
 ```
 
 ## Commands


### PR DESCRIPTION
#### 📲 What

Tokens had been left in the document, this has not been replaced with the version of the Stacks CLI.

#### 🤔 Why
		
The examples shown the documentation show how to download the CLI. However the token `{stackscli_version}` would refer to an incorrect URL.
		
#### 🛠 How
		
String replaced `{stackscli_version}` with `0.0.218` which is the latest version of the CLI.

#### 👀 Evidence
		
Links are now valid.

![image](https://user-images.githubusercontent.com/791658/148921818-7c1db85d-aeb9-4a85-bc31-101822b4afd9.png)
		 
#### 🕵️ How to test

Test the cod snippet as shown in the documentation.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
