### PR TITLE
fix: divs in details section being unnecessarily padded

### DIFF
--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -439,7 +439,7 @@ div details summary {
   cursor: pointer;
 }
 
-div details div {
+div details > div {
   padding-top: 20px;
   padding-left: 20px;
 }


### PR DESCRIPTION
Before:

<img width="819" alt="Screenshot 2023-01-31 at 12 49 02" src="https://user-images.githubusercontent.com/802141/215774140-b9b0c3d8-a89c-413e-b1cf-49a52ec65e48.png">

After:

<img width="840" alt="Screenshot 2023-01-31 at 14 32 58" src="https://user-images.githubusercontent.com/802141/215774372-78fc0be3-43a8-4e75-95c0-a6c352a251b0.png">


