### PR TITLE
docs: add nx.json stacks field example to workspace init docs

### DIFF
--- a/docs/nx/workspace/init.md
+++ b/docs/nx/workspace/init.md
@@ -7,6 +7,42 @@ Set up libraries to manage code & commit quality, keeping projects consistent an
 
 Allows you to choose your recommended 3rd party provider options.
 
+## Prerequisites
+
+This generator depends on the `stacks` field within `nx.json`.
+If you have already run Stacks CLI or `create-stacks-workspace`, this field will automatically be populated.
+If you are Stackifying an existing Nx workspace, this must be added manually - an example `stacks` field can be seen here:
+
+```json
+{
+  "stacks": {
+    "business": {
+      "company": "Ensono",
+      "domain": "stacks",
+      "component": "nx"
+    },
+    "domain": {
+      "internal": "test.com",
+      "external": "test.dev"
+    },
+    "cloud": {
+      "platform": "azure",
+      "region": "euw"
+    },
+    "pipeline": "azdo",
+    "terraform": {
+      "group": "terraform-group",
+      "storage": "terraform-storage",
+      "container": "terraform-container"
+    },
+    "vcs": {
+      "type": "github",
+      "url": "remote.git"
+    }
+  }
+}
+```
+
 ## Usage
 
 Initialise your NX workspace with stacks with the following command:

--- a/docs/nx/workspace/init.md
+++ b/docs/nx/workspace/init.md
@@ -9,8 +9,8 @@ Allows you to choose your recommended 3rd party provider options.
 
 ## Prerequisites
 
-This generator depends on the `stacks` field within `nx.json`.
-If you have already run Stacks CLI or `create-stacks-workspace`, this field will automatically be populated.
+To scaffold your workspace with infrastructure there is a dependency on the `stacks` field within `nx.json`.
+If you have already run the Stacks CLI these fields will be automatically populated. Alternatively, if you created your workspace with `create-stacks-workspace`, these fields will have been populated if you passed in the relevant CLI arguments.
 If you are Stackifying an existing Nx workspace, this must be added manually - an example `stacks` field can be seen here:
 
 ```json

--- a/docs/nx/workspace/init.md
+++ b/docs/nx/workspace/init.md
@@ -43,6 +43,8 @@ If you are Stackifying an existing Nx workspace, this must be added manually - a
 }
 ```
 
+Please see the [Stacks CLI documentation](https://stacks.amido.com/docs/stackscli/about) for information on each of these values.
+
 ## Usage
 
 Initialise your NX workspace with stacks with the following command:


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Add an example `stacks` field that can be added to `nx.json` to the `workspace/init` docs.
<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message, 
e.g. Implements `[AB#1228](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1228) - Link tickets to GitHub`
-->

#### 🤔 Why
		
One of our suggested workflows is to Stackify an existing Nx workspace using `@ensono-stacks/init`. This errors unless you have a correct `stacks` field in your `nx.json`, which is not currently documented as part of that journey.
		
#### 🛠 How
		
Copied example from https://stacks.amido.com/docs/nx/next/ensono-stacks-next#ensono-stacksnextinfrastructure

#### 👀 Evidence
		
N/A
		 
#### 🕵️ How to test

Look at the docs

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
