### PR TITLE
docs: add prerequisite of latest Node.js LTS version

### DIFF
--- a/docs/nx/nx_monorepo.md
+++ b/docs/nx/nx_monorepo.md
@@ -57,6 +57,7 @@ Nx makes scaling easy. Modern techniques such as distributed task execution and 
 
 ### Prerequisites
 
+#### Nx
 We recommend installing Nx globally, all Nx based commands in this guide are based upon a globally installed Nx package.
 
 <Tabs>
@@ -75,6 +76,10 @@ yarn global add nx
 
   </TabItem>
 </Tabs>
+
+#### Node
+We recommend using the latest LTS version of Node, you can find the latest LTS version [here](https://nodejs.org/en/).
+
 
 ### Get Started
 

--- a/docs/nx/nx_monorepo.md
+++ b/docs/nx/nx_monorepo.md
@@ -58,6 +58,7 @@ Nx makes scaling easy. Modern techniques such as distributed task execution and 
 ### Prerequisites
 
 #### Nx
+
 We recommend installing Nx globally, all Nx based commands in this guide are based upon a globally installed Nx package.
 
 <Tabs>
@@ -78,8 +79,8 @@ yarn global add nx
 </Tabs>
 
 #### Node
-We recommend using the latest LTS version of Node, you can find the latest LTS version [here](https://nodejs.org/en/).
 
+We recommend using the latest LTS version of Node, you can find the latest LTS version [here](https://nodejs.org/en/).
 
 ### Get Started
 


### PR DESCRIPTION
#### 🤔 Why
		
The latest LTS version of Node.js (currently 18.16.1) is required to avoid errors when running stacks commands.