### PR TITLE
feat: Add Content-Security-Policy meta tag for GitHub Pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ require('dotenv').config();
 /** @type {import('@docusaurus/types').Config} */
 
 // Content Security Policy directives for GitHub Pages (meta tag based)
-// Note: Report-Only mode is not supported via meta tags, only via HTTP headers
+// Note: Report-Only mode and frame-ancestors are not supported via meta tags, only via HTTP headers
 // This policy is enforced directly - test thoroughly before deployment
 const cspDirectives = [
   "default-src 'self'",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,20 +7,59 @@ const {themes} = require('prism-react-renderer');
 require('dotenv').config();
 /** @type {import('@docusaurus/types').Config} */
 
+// Content Security Policy directives for GitHub Pages (meta tag based)
+// Note: Report-Only mode is not supported via meta tags, only via HTTP headers
+// This policy is enforced directly - test thoroughly before deployment
+const cspDirectives = [
+  "default-src 'self'",
+  // Scripts: 'unsafe-inline' required for Docusaurus theme init, gtag, and runtime scripts
+  "script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://www.googletagmanager.com",
+  // Styles: 'unsafe-inline' required for react-select Emotion CSS-in-JS
+  "style-src 'self' 'unsafe-inline'",
+  // Images: Google Analytics pixel tracking
+  "img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com",
+  // Fonts: Self-hosted only (Inter, Plus Jakarta Sans)
+  "font-src 'self'",
+  // API connections: Algolia search, Google Analytics (includes regional endpoints)
+  "connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://*.algolia.net https://*.algolianet.com",
+  // Embedded frames: YouTube for ReactPlayer video embeds
+  "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
+  // Form submissions
+  "form-action 'self'",
+  // Base URI restriction
+  "base-uri 'self'",
+  // Object/embed elements (Flash, etc.) - not needed
+  "object-src 'none'",
+  // Upgrade insecure requests
+  "upgrade-insecure-requests"
+].join('; ');
+
 const config = {
   title: "Ensono Stacks",
   tagline:
     "Helping projects gain momentum on digital transformation, with opinionated and modular boilerplate solutions",
   url: "https://stacks.ensono.com",
   baseUrl: "/",
+  baseUrlIssueBanner: false, // Disabled to reduce inline scripts for CSP
   trailingSlash: false,
   onBrokenLinks: "warn",
   favicon: "img/icons/favicon.ico",
+  // Content Security Policy meta tag for GitHub Pages
+  headTags: [
+    {
+      tagName: "meta",
+      attributes: {
+        "http-equiv": "Content-Security-Policy",
+        content: cspDirectives,
+      },
+    },
+  ],
   organizationName: "Ensono", // Usually your GitHub org/user name.
   projectName: "amido.github.io", // Usually your repo name.
   customFields: {
-    description: 'Ensono Stacks is a catalogue of workload templates that\n' +
-        'instantly scaffold and deploy boilerplate software projects. Slash the time it takes to get productive on your software project.',
+    description:
+      "Ensono Stacks is a catalogue of workload templates that\n" +
+      "instantly scaffold and deploy boilerplate software projects. Slash the time it takes to get productive on your software project.",
     keywords: [
       "Microsoft Azure",
       "Google Cloud Platform",
@@ -50,7 +89,7 @@ const config = {
       appId: process.env.ALGOLIA_APP_ID,
       apiKey: process.env.ALGOLIA_API_KEY,
       indexName: process.env.ALGOLIA_INDEX_NAME,
-    }
+    },
   },
   themeConfig: {
     colorMode: {
@@ -59,7 +98,14 @@ const config = {
     prism: {
       theme: themes.github,
       darkTheme: themes.vsDark,
-      additionalLanguages: ['csharp', 'docker', 'powershell', 'java', 'bash', 'json'],
+      additionalLanguages: [
+        "csharp",
+        "docker",
+        "powershell",
+        "java",
+        "bash",
+        "json",
+      ],
     },
     navbar: {
       title: "",
@@ -69,7 +115,7 @@ const config = {
         href: "/",
         width: 150,
         height: 36,
-        className: "custom-navbar-logo-class"
+        className: "custom-navbar-logo-class",
       },
       items: [
         {
@@ -84,11 +130,11 @@ const config = {
         {
           href: "https://www.ensono.com/company/lets-connect/",
           label: "Connect",
-          position: 'right'
+          position: "right",
         },
       ],
     },
-    footer: {      
+    footer: {
       links: [
         {
           title: "Documentation",
@@ -96,7 +142,7 @@ const config = {
             {
               label: "Getting Started",
               to: "docs/",
-            }
+            },
           ],
         },
         {
@@ -133,27 +179,27 @@ const config = {
       "@docusaurus/preset-classic",
       {
         docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-            remarkPlugins: [remarkImages.default || remarkImages],
+          sidebarPath: require.resolve("./sidebars.js"),
+          remarkPlugins: [remarkImages.default || remarkImages],
         },
         theme: {
-          customCss: require.resolve("./src/css/custom.css")
+          customCss: require.resolve("./src/css/custom.css"),
         },
         sitemap: {
           changefreq: "weekly",
-          priority: 0.5
+          priority: 0.5,
         },
         gtag: {
-          trackingID: 'G-EKCQBC5CSJ',
+          trackingID: "G-EKCQBC5CSJ",
           anonymizeIP: true, // Should IPs be anonymized? (optional)
         },
         googleAnalytics: {
-          trackingID: 'G-EKCQBC5CSJ',
+          trackingID: "G-EKCQBC5CSJ",
           anonymizeIP: true, // Should IPs be anonymized?
         },
-      }
-    ]
-  ]
+      },
+    ],
+  ],
 };
 
 module.exports = config;


### PR DESCRIPTION
## Summary

Implements a Content-Security-Policy (CSP) via meta tag for the Ensono Stacks documentation site deployed on GitHub Pages. Since GitHub Pages does not support custom HTTP headers, this uses the `<meta http-equiv="Content-Security-Policy">` approach via Docusaurus's `headTags` configuration.

## Problem

The site was previously deployed without any Content-Security-Policy header, leaving it vulnerable to XSS attacks and other injection-based security issues.

## Solution

Added a comprehensive CSP meta tag in `docusaurus.config.js` that:

1. **Restricts default sources** to same-origin (`'self'`)
2. **Whitelists required external domains**:
   - Google Analytics (`www.google-analytics.com`, `*.google-analytics.com`, `www.googletagmanager.com`)
   - Algolia DocSearch (`*.algolia.net`, `*.algolianet.com`)
   - YouTube for ReactPlayer video embeds (`www.youtube.com`, `www.youtube-nocookie.com`)
3. **Blocks dangerous features**:
   - `object-src 'none'` - Prevents Flash/plugin-based attacks
   - `upgrade-insecure-requests` - Forces HTTPS
4. **Disables `baseUrlIssueBanner`** to reduce inline script sources

### CSP Directives

| Directive | Value | Reason |
|-----------|-------|--------|
| `default-src` | `'self'` | Restrict to same-origin by default |
| `script-src` | `'self' 'unsafe-inline'` + GA/GTM domains | Required for Docusaurus theme init and analytics |
| `style-src` | `'self' 'unsafe-inline'` | Required for react-select's Emotion CSS-in-JS |
| `img-src` | `'self' data:` + GA domains | Allows SVGs, data URIs, and GA pixels |
| `font-src` | `'self'` | Fonts are self-hosted (Inter, Plus Jakarta Sans) |
| `connect-src` | `'self'` + GA/Algolia domains | API connections for search and analytics |
| `frame-src` | `'self'` + YouTube | ReactPlayer video embeds |
| `form-action` | `'self'` | Form submissions restricted to same-origin |
| `object-src` | `'none'` | Block Flash/plugins |
| `upgrade-insecure-requests` | - | Auto-upgrade HTTP to HTTPS |

## Testing Performed

Comprehensive testing was performed using Chrome DevTools MCP Server:

### Pages Tested ✅

| Test | Page | Result |
|------|------|--------|
| Homepage | `/` | ✅ Pass - No CSP errors, all assets loaded |
| Documentation main | `/docs` | ✅ Pass - No CSP errors |
| Sidebar navigation | `/docs` | ✅ Pass - Expand/collapse works |
| Infrastructure docs | `/docs/infrastructure/azure/core_infrastructure` | ✅ Pass - Images and tables render |
| CLI MDX page | `/docs/stackscli/usage` | ✅ Pass - Screenshots display correctly |
| React-Select dropdown | `/#stacks-selector` | ✅ Pass - CSS-in-JS styles work |
| Dropdown selection | `/#stacks-selector` | ✅ Pass - Dynamic updates work |
| 404 page | `/nonexistent-page` | ✅ Pass - Error page renders |
| Testing overview | `/docs/testing/testing_overview` | ✅ Pass - Complex tables render |
| Workloads intro | `/docs/workloads` | ✅ Pass - Content displays |
| Linting docs | `/docs/linting/eslint` | ✅ Pass - Admonitions render |

### Network Requests Verified ✅

- `www.google-analytics.com` - Allowed
- `www.googletagmanager.com` - Allowed
- `region1.google-analytics.com` - Allowed
- All local assets (JS, CSS, fonts, images) - Allowed

### Console Errors Checked ✅

- No CSP violation errors on any tested page
- Google Analytics tracking requests succeed
- All fonts, images, and scripts load correctly

## Known Limitations

1. **`'unsafe-inline'` required**: Both `script-src` and `style-src` require `'unsafe-inline'` due to:
   - Docusaurus inline scripts (theme initialization, gtag)
   - react-select's Emotion CSS-in-JS runtime styles
   
   Removing these would require replacing react-select with a non-CSS-in-JS component and modifying Docusaurus core.

2. **Report-Only mode not available**: `Content-Security-Policy-Report-Only` via meta tags is not supported by browsers - only HTTP headers can use report-only mode.

3. **`frame-ancestors` not available**: The `frame-ancestors` directive cannot be set via meta tags (only HTTP headers), so clickjacking protection at the frame level is not included.

## Backout Plan

If issues are discovered after deployment:
1. Revert this commit
2. Or modify the CSP directives in `docusaurus.config.js` to be more permissive

## Security Impact

- ✅ Mitigates XSS attacks by restricting script/style sources
- ✅ Prevents plugin-based attacks via `object-src 'none'`
- ✅ Forces HTTPS via `upgrade-insecure-requests`
- ✅ Restricts form submissions to same-origin
- ⚠️ `'unsafe-inline'` reduces protection but is required for site functionality

## Checklist

- [x] CSP meta tag added to `docusaurus.config.js`
- [x] All required external domains whitelisted
- [x] Build succeeds (`npm run build`)
- [x] Comprehensive browser testing performed
- [x] No CSP violations on tested pages
- [x] Google Analytics tracking works
- [x] React-Select dropdown works (CSS-in-JS)
- [x] Documentation pages render correctly