### PR TITLE
fix(site): disable analytics in local development

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,10 +1,12 @@
 {
     "version": "0.2",
     "words": [
-      "Ensono",
-      "unwelcomed",
-      "amidostacks",
-      "humaning",
-      "fuzzies"
+        "amidostacks",
+        "Ensono",
+        "fuzzies",
+        "gtag",
+        "humaning",
+        "smol",
+        "unwelcomed"
     ]
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,9 @@ const remarkImages = require('remark-images');
 const {themes} = require('prism-react-renderer');
 
 require('dotenv').config();
+const enableAnalytics = process.argv.some((arg) =>
+  ["build", "deploy"].includes(arg),
+);
 /** @type {import('@docusaurus/types').Config} */
 
 const config = {
@@ -19,8 +22,9 @@ const config = {
   organizationName: "Ensono", // Usually your GitHub org/user name.
   projectName: "amido.github.io", // Usually your repo name.
   customFields: {
-    description: 'Ensono Stacks is a catalogue of workload templates that\n' +
-        'instantly scaffold and deploy boilerplate software projects. Slash the time it takes to get productive on your software project.',
+    description:
+      "Ensono Stacks is a catalogue of workload templates that\n" +
+      "instantly scaffold and deploy boilerplate software projects. Slash the time it takes to get productive on your software project.",
     keywords: [
       "Microsoft Azure",
       "Google Cloud Platform",
@@ -50,7 +54,7 @@ const config = {
       appId: process.env.ALGOLIA_APP_ID,
       apiKey: process.env.ALGOLIA_API_KEY,
       indexName: process.env.ALGOLIA_INDEX_NAME,
-    }
+    },
   },
   themeConfig: {
     colorMode: {
@@ -59,7 +63,14 @@ const config = {
     prism: {
       theme: themes.github,
       darkTheme: themes.vsDark,
-      additionalLanguages: ['csharp', 'docker', 'powershell', 'java', 'bash', 'json'],
+      additionalLanguages: [
+        "csharp",
+        "docker",
+        "powershell",
+        "java",
+        "bash",
+        "json",
+      ],
     },
     navbar: {
       title: "",
@@ -69,7 +80,7 @@ const config = {
         href: "/",
         width: 150,
         height: 36,
-        className: "custom-navbar-logo-class"
+        className: "custom-navbar-logo-class",
       },
       items: [
         {
@@ -84,11 +95,11 @@ const config = {
         {
           href: "https://www.ensono.com/company/lets-connect/",
           label: "Connect",
-          position: 'right'
+          position: "right",
         },
       ],
     },
-    footer: {      
+    footer: {
       links: [
         {
           title: "Documentation",
@@ -96,7 +107,7 @@ const config = {
             {
               label: "Getting Started",
               to: "docs/",
-            }
+            },
           ],
         },
         {
@@ -133,27 +144,27 @@ const config = {
       "@docusaurus/preset-classic",
       {
         docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-            remarkPlugins: [remarkImages.default || remarkImages],
+          sidebarPath: require.resolve("./sidebars.js"),
+          remarkPlugins: [remarkImages.default || remarkImages],
         },
         theme: {
-          customCss: require.resolve("./src/css/custom.css")
+          customCss: require.resolve("./src/css/custom.css"),
         },
         sitemap: {
           changefreq: "weekly",
-          priority: 0.5
+          priority: 0.5,
         },
-        gtag: {
-          trackingID: 'G-EKCQBC5CSJ',
-          anonymizeIP: true, // Should IPs be anonymized? (optional)
-        },
-        googleAnalytics: {
-          trackingID: 'G-EKCQBC5CSJ',
-          anonymizeIP: true, // Should IPs be anonymized?
-        },
-      }
-    ]
-  ]
+        ...(enableAnalytics
+          ? {
+              gtag: {
+                trackingID: "G-EKCQBC5CSJ",
+                anonymizeIP: true, // Should IPs be anonymized? (optional)
+              },
+            }
+          : {}),
+      },
+    ],
+  ],
 };
 
 module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "dependencies": {
         "@analytics/google-analytics": "^1.1.0",
         "@docsearch/react": "^4.6.3",
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/mdx-loader": "3.10.0",
-        "@docusaurus/plugin-google-analytics": "3.10.0",
-        "@docusaurus/plugin-google-gtag": "3.10.0",
-        "@docusaurus/plugin-sitemap": "3.10.0",
-        "@docusaurus/preset-classic": "3.10.0",
+        "@docusaurus/core": "^3.10.1",
+        "@docusaurus/mdx-loader": "^3.10.1",
+        "@docusaurus/plugin-google-analytics": "^3.10.1",
+        "@docusaurus/plugin-google-gtag": "3.10.1",
+        "@docusaurus/plugin-sitemap": "3.10.1",
+        "@docusaurus/preset-classic": "3.10.1",
         "@mdx-js/react": "^3.1.1",
         "clsx": "^2.1.1",
         "dotenv": "^17.4.2",
@@ -27,8 +27,8 @@
         "remark-images": "^4.1.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.10.0",
-        "cspell": "^9.7.0",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "cspell": "^10.0.0",
         "markdownlint": "^0.40.0",
         "markdownlint-cli": "^0.48.0"
       },
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -394,9 +394,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
+      "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -404,7 +404,7 @@
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.28.6",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -692,6 +692,22 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.3.tgz",
+      "integrity": "sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1767,18 +1783,19 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
-      "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.3.tgz",
+      "integrity": "sha512-ySZypNLAIH1ClygLDQzVMoGQRViATnkHkYYV6TcNDz+8+jwZCdsguGvsb3EY5d9wyWyhmF1iSuFM0Yh5XPnqSA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.29.0",
+        "@babel/compat-data": "^7.29.3",
         "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.3",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
         "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
@@ -1990,9 +2007,9 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.7.0.tgz",
-      "integrity": "sha512-s7h1vo++Q3AsfQa3cs0u/KGwm3SYInuIlC4kjlCBWjQmb4KddiZB5O1u0+3TlA7GycHb5M4CR7MDfHUICgJf+w==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.0.0.tgz",
+      "integrity": "sha512-ci410HEkng2582oOjlRHQtlGXwh+rUC/mVcN9dObLHpKhvPgzn2S6vT56pARstxxZpcCUG/oLhn3dCqdJlVzmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2000,54 +2017,54 @@
         "@cspell/dict-al": "^1.1.1",
         "@cspell/dict-aws": "^4.0.17",
         "@cspell/dict-bash": "^4.2.2",
-        "@cspell/dict-companies": "^3.2.10",
+        "@cspell/dict-companies": "^3.2.11",
         "@cspell/dict-cpp": "^7.0.2",
         "@cspell/dict-cryptocurrencies": "^5.0.5",
         "@cspell/dict-csharp": "^4.0.8",
-        "@cspell/dict-css": "^4.0.19",
+        "@cspell/dict-css": "^4.1.1",
         "@cspell/dict-dart": "^2.3.2",
         "@cspell/dict-data-science": "^2.0.13",
         "@cspell/dict-django": "^4.1.6",
         "@cspell/dict-docker": "^1.1.17",
-        "@cspell/dict-dotnet": "^5.0.12",
+        "@cspell/dict-dotnet": "^5.0.13",
         "@cspell/dict-elixir": "^4.0.8",
-        "@cspell/dict-en_us": "^4.4.29",
+        "@cspell/dict-en_us": "^4.4.33",
         "@cspell/dict-en-common-misspellings": "^2.1.12",
-        "@cspell/dict-en-gb-mit": "^3.1.18",
-        "@cspell/dict-filetypes": "^3.0.15",
+        "@cspell/dict-en-gb-mit": "^3.1.22",
+        "@cspell/dict-filetypes": "^3.0.18",
         "@cspell/dict-flutter": "^1.1.1",
-        "@cspell/dict-fonts": "^4.0.5",
+        "@cspell/dict-fonts": "^4.0.6",
         "@cspell/dict-fsharp": "^1.1.1",
-        "@cspell/dict-fullstack": "^3.2.8",
+        "@cspell/dict-fullstack": "^3.2.9",
         "@cspell/dict-gaming-terms": "^1.1.2",
         "@cspell/dict-git": "^3.1.0",
         "@cspell/dict-golang": "^6.0.26",
         "@cspell/dict-google": "^1.0.9",
         "@cspell/dict-haskell": "^4.0.6",
-        "@cspell/dict-html": "^4.0.14",
+        "@cspell/dict-html": "^4.0.15",
         "@cspell/dict-html-symbol-entities": "^4.0.5",
         "@cspell/dict-java": "^5.0.12",
         "@cspell/dict-julia": "^1.1.1",
         "@cspell/dict-k8s": "^1.0.12",
         "@cspell/dict-kotlin": "^1.1.1",
-        "@cspell/dict-latex": "^5.0.0",
+        "@cspell/dict-latex": "^5.1.0",
         "@cspell/dict-lorem-ipsum": "^4.0.5",
         "@cspell/dict-lua": "^4.0.8",
         "@cspell/dict-makefile": "^1.0.5",
-        "@cspell/dict-markdown": "^2.0.14",
+        "@cspell/dict-markdown": "^2.0.16",
         "@cspell/dict-monkeyc": "^1.0.12",
         "@cspell/dict-node": "^5.0.9",
-        "@cspell/dict-npm": "^5.2.34",
+        "@cspell/dict-npm": "^5.2.38",
         "@cspell/dict-php": "^4.1.1",
         "@cspell/dict-powershell": "^5.0.15",
-        "@cspell/dict-public-licenses": "^2.0.15",
-        "@cspell/dict-python": "^4.2.25",
+        "@cspell/dict-public-licenses": "^2.0.16",
+        "@cspell/dict-python": "^4.2.26",
         "@cspell/dict-r": "^2.1.1",
-        "@cspell/dict-ruby": "^5.1.0",
+        "@cspell/dict-ruby": "^5.1.1",
         "@cspell/dict-rust": "^4.1.2",
         "@cspell/dict-scala": "^5.0.9",
         "@cspell/dict-shell": "^1.1.2",
-        "@cspell/dict-software-terms": "^5.1.21",
+        "@cspell/dict-software-terms": "^5.2.2",
         "@cspell/dict-sql": "^2.2.1",
         "@cspell/dict-svelte": "^1.0.7",
         "@cspell/dict-swift": "^2.0.6",
@@ -2057,87 +2074,87 @@
         "@cspell/dict-zig": "^1.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.7.0.tgz",
-      "integrity": "sha512-6xpGXlMtQA3hV2BCAQcPkpx9eI12I0o01i9eRqSSEDKtxuAnnrejbcCpL+5OboAjTp3/BSeNYSnhuWYLkSITWQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.0.0.tgz",
+      "integrity": "sha512-hq5dui2ngYMZKbBauX7K1tkqlu81sX/uaCO49ZJLPjeZsE1auZLtHehDLfAr/ZXoj/dLYeQMSKiaJyE+qLVPHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.7.0"
+        "@cspell/cspell-types": "10.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-performance-monitor": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-9.7.0.tgz",
-      "integrity": "sha512-w1PZIFXuvjnC6mQHyYAFnrsn5MzKnEcEkcK1bj4OG00bAt7WX2VUA/eNNt9c1iHozCQ+FcRYlfbGxuBmNyzSgw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.0.0.tgz",
+      "integrity": "sha512-2vMh2pLt2dg/ArYvWjMP4v9HCm0pRhONsEJyc8oHdZyOYvX7trixX894I0M39+VBf3yWtPCEgYRh1UDXNIZRig==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.7.0.tgz",
-      "integrity": "sha512-iiisyRpJciU9SOHNSi0ZEK0pqbEMFRatI/R4O+trVKb+W44p4MNGClLVRWPGUmsFbZKPJL3jDtz0wPlG0/JCZA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.0.0.tgz",
+      "integrity": "sha512-qcgHhQvtEX8LSwIVsWrdUgiGim52lN3jT+ghlkdp72v+nBcGKsS2frEKTmbGLug+xcqppkzs6Q6VmsFp1MGtfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.7.0.tgz",
-      "integrity": "sha512-uiEgS238mdabDnwavo6HXt8K98jlh/jpm7NONroM9NTr9rzck2VZKD2kXEj85wDNMtRsRXNoywTjwQ8WTB6/+w==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.0.0.tgz",
+      "integrity": "sha512-8H+IUDB7SmrpcRugQ5f55qG81ZShk6nQRk+natLz41TEY98D8/LCmjHEkh/vhDPph9pVJmNUp7JcM2E1UHEa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "global-directory": "^5.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.7.0.tgz",
-      "integrity": "sha512-fkqtaCkg4jY/FotmzjhIavbXuH0AgUJxZk78Ktf4XlhqOZ4wDeUWrCf220bva4mh3TWiLx/ae9lIlpl59Vx6hA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.0.0.tgz",
+      "integrity": "sha512-V7eigqg/TOoKwNK4Q18wr9KGxA8U5SFcoWVS8RyAxv4mQ+yNKHhvHEbRBifjPbQDer66afOrclb2UbqkIy2SOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.7.0.tgz",
-      "integrity": "sha512-Tdfx4eH2uS+gv9V9NCr3Rz+c7RSS6ntXp3Blliud18ibRUlRxO9dTaOjG4iv4x0nAmMeedP1ORkEpeXSkh2QiQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.0.0.tgz",
+      "integrity": "sha512-IQA++Idqb8fZzkCbHq3+T+9yG9WpeaBxomOrG2KcR/Pj0CgnovzuApYKL2cc35UWLePboKinMeqEPiweFpHVug==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-worker": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-9.7.0.tgz",
-      "integrity": "sha512-cjEApFF0aOAa1vTUk+e7xP8ofK7iC7hsRzj1FmvvVQz8PoLWPRaq+1bT89ypPsZQvavqm5sIgb97S60/aW4TVg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.0.0.tgz",
+      "integrity": "sha512-V5bjMldNksilnja3fu8muQmkW5/guyua1yNVOhoE2r7othSvjuDlGMl8g2bQSrWjp+UXu0dP/BEZ6JC/IfNwTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cspell-lib": "9.7.0"
+        "cspell-lib": "10.0.0"
       },
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/dict-ada": {
@@ -2172,9 +2189,9 @@
       }
     },
     "node_modules/@cspell/dict-companies": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.10.tgz",
-      "integrity": "sha512-bJ1qnO1DkTn7JYGXvxp8FRQc4yq6tRXnrII+jbP8hHmq5TX5o1Wu+rdfpoUQaMWTl6balRvcMYiINDesnpR9Bw==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.11.tgz",
+      "integrity": "sha512-0cmafbcz2pTHXLd59eLR1gvDvN6aWAOM0+cIL4LLF9GX9yB2iKDNrKsvs4tJRqutoaTdwNFBbV0FYv+6iCtebQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2200,9 +2217,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-css": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.19.tgz",
-      "integrity": "sha512-VYHtPnZt/Zd/ATbW3rtexWpBnHUohUrQOHff/2JBhsVgxOrksAxJnLAO43Q1ayLJBJUUwNVo+RU0sx0aaysZfg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.1.tgz",
+      "integrity": "sha512-y/Vgo6qY08e1t9OqR56qjoFLBCpi4QfWMf2qzD1l9omRZwvSMQGRPz4x0bxkkkU4oocMAeztjzCsmLew//c/8w==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2236,9 +2253,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-dotnet": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.12.tgz",
-      "integrity": "sha512-FiV934kNieIjGTkiApu/WKvLYi/KBpvfWB2TSqpDQtmXZlt3uSa5blwblO1ZC8OvjH8RCq/31H5IdEYmTaZS7A==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.13.tgz",
+      "integrity": "sha512-xPp7jMnFpOri7tzmqmm/dXMolXz1t2bhNqxYkOyMqXhvs08oc7BFs+EsbDY0X7hqiISgeFZGNqn0dOCr+ncPYw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2250,9 +2267,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.4.29",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.29.tgz",
-      "integrity": "sha512-G3B27++9ziRdgbrY/G/QZdFAnMzzx17u8nCb2Xyd4q6luLpzViRM/CW3jA+Mb/cGT5zR/9N+Yz9SrGu1s0bq7g==",
+      "version": "4.4.33",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.33.tgz",
+      "integrity": "sha512-zWftVqfUStDA37wO1ZNDN1qMJOfcxELa8ucHW8W8wBAZY3TK5Nb6deLogCK/IJi/Qljf30dwwuqqv84Qqle9Tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2264,16 +2281,16 @@
       "license": "CC BY-SA 4.0"
     },
     "node_modules/@cspell/dict-en-gb-mit": {
-      "version": "3.1.18",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.18.tgz",
-      "integrity": "sha512-AXaMzbaxhSc32MSzKX0cpwT+Thv1vPfxQz1nTly1VHw3wQcwPqVFSqrLOYwa8VNqAPR45583nnhD6iqJ9YESoQ==",
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.22.tgz",
+      "integrity": "sha512-xE5Vg6gGdMkZ1Ep6z9SJMMioGkkT1GbxS5Mm0U3Ey1/H68P0G7cJcyiVr1CARxFbLqKE4QUpoV1o6jz1Z5Yl9Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-filetypes": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.16.tgz",
-      "integrity": "sha512-SyrtuK2/sx+cr94jOp2/uOAb43ngZEVISUTRj4SR6SfoGULVV1iJS7Drqn7Ul9HJ731QDttwWlOUgcQ+yMRblg==",
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.18.tgz",
+      "integrity": "sha512-yU7RKD/x1IWmDLzWeiItMwgV+6bUcU/af23uS0+uGiFUbsY1qWV/D4rxlAAO6Z7no3J2z8aZOkYIOvUrJq0Rcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2285,9 +2302,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-fonts": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.5.tgz",
-      "integrity": "sha512-BbpkX10DUX/xzHs6lb7yzDf/LPjwYIBJHJlUXSBXDtK/1HaeS+Wqol4Mlm2+NAgZ7ikIE5DQMViTgBUY3ezNoQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.6.tgz",
+      "integrity": "sha512-aR/0csY01dNb0A1tw/UmN9rKgHruUxsYsvXu6YlSBJFu60s26SKr/k1o4LavpHTQ+lznlYMqAvuxGkE4Flliqw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2299,9 +2316,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-fullstack": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.8.tgz",
-      "integrity": "sha512-J6EeoeThvx/DFrcA2rJiCA6vfqwJMbkG0IcXhlsmRZmasIpanmxgt90OEaUazbZahFiuJT8wrhgQ1QgD1MsqBw==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.9.tgz",
+      "integrity": "sha512-diZX+usW5aZ4/b2T0QM/H/Wl9aNMbdODa1Jq0ReBr/jazmNeWjd+PyqeVgzd1joEaHY+SAnjrf/i9CwKd2ZtWQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2341,9 +2358,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-html": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.14.tgz",
-      "integrity": "sha512-2bf7n+kS92g+cMKV0wr9o/Oq9n8JzU7CcrB96gIh2GHgnF+0xDOqO2W/1KeFAqOfqosoOVE48t+4dnEMkkoJ2Q==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
+      "integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2413,14 +2430,14 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-markdown": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.14.tgz",
-      "integrity": "sha512-uLKPNJsUcumMQTsZZgAK9RgDLyQhUz/uvbQTEkvF/Q4XfC1i/BnA8XrOrd0+Vp6+tPOKyA+omI5LRWfMu5K/Lw==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.16.tgz",
+      "integrity": "sha512-976RRqKv6cwhrxdFCQP2DdnBVB86BF57oQtPHy4Zbf4jF/i2Oy29MCrxirnOBalS1W6KQeto7NdfDXRAwkK4PQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@cspell/dict-css": "^4.0.19",
-        "@cspell/dict-html": "^4.0.14",
+        "@cspell/dict-css": "^4.1.1",
+        "@cspell/dict-html": "^4.0.15",
         "@cspell/dict-html-symbol-entities": "^4.0.5",
         "@cspell/dict-typescript": "^3.2.3"
       }
@@ -2440,9 +2457,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.2.35",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.35.tgz",
-      "integrity": "sha512-w0VIDUvzHSTt4S9pfvSatApxtCesLMFrDUYD0Wjtw91EBRkB2wVw/RV3q1Ni9Nzpx6pCFpcB7c1xBY8l22cyiQ==",
+      "version": "5.2.38",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.38.tgz",
+      "integrity": "sha512-21ucGRPYYhr91C2cDBoMPTrcIOStQv33xOqJB0JLoC5LAs2Sfj9EoPGhGb+gIFVHz6Ia7JQWE2SJsOVFJD1wmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2468,9 +2485,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.25",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.25.tgz",
-      "integrity": "sha512-hDdN0YhKgpbtZVRjQ2c8jk+n0wQdidAKj1Fk8w7KEHb3YlY5uPJ0mAKJk7AJKPNLOlILoUmN+HAVJz+cfSbWYg==",
+      "version": "4.2.26",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.26.tgz",
+      "integrity": "sha512-hbjN6BjlSgZOG2dA2DtvYNGBM5Aq0i0dHaZjMOI9K/9vRicVvKbcCiBSSrR3b+jwjhQL5ff7HwG5xFaaci0GQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2485,9 +2502,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-ruby": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.1.0.tgz",
-      "integrity": "sha512-9PJQB3cfkBULrMLp5kSAcFPpzf8oz9vFN+QYZABhQwWkGbuzCIXSorHrmWSASlx4yejt3brjaWS57zZ/YL5ZQQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.1.1.tgz",
+      "integrity": "sha512-LHrp84oEV6q1ZxPPyj4z+FdKyq1XAKYPtmGptrd+uwHbrF/Ns5+fy6gtSi7pS+uc0zk3JdO9w/tPK+8N1/7WUA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2513,9 +2530,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "5.1.22",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.22.tgz",
-      "integrity": "sha512-ELi8wqyDAreDpo17Pu45AuKvcrhqPCkGeL+DMuSVxEimBwEqPB+KeQ89DkVap6QDJHl3LCth0pjv8uOgS1dtdQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.2.tgz",
+      "integrity": "sha512-0CaYd6TAsKtEoA7tNswm1iptEblTzEe3UG8beG2cpSTHk7afWIVMtJLgXDv0f/Li67Lf3Z1Jf3JeXR7GsJ2TRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2570,57 +2587,57 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.7.0.tgz",
-      "integrity": "sha512-Ws36IYvtS/8IN3x6K9dPLvTmaArodRJmzTn2Rkf2NaTnIYWhRuFzsP3SVVO59NN3fXswAEbmz5DSbVUe8bPZHg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.0.0.tgz",
+      "integrity": "sha512-fMqu/5Ma1Q5ZCR/Par+Q4pvaTKmx5pKZzQmkwld2hNounVdk2OaIPM9MzpNn6I1mLk5J+wTnIZmfcWNAzNP9aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.7.0",
+        "@cspell/url": "10.0.0",
         "import-meta-resolve": "^4.2.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.7.0.tgz",
-      "integrity": "sha512-Ln9e/8wGOyTeL3DCCs6kwd18TSpTw3kxsANjTrzLDASrX4cNmAdvc9J5dcIuBHPaqOAnRQxuZbzUlpRh73Y24w==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.0.0.tgz",
+      "integrity": "sha512-UP57j9yrDtlCHpFxc/eGho1m8DP5olfu9KRWwd5fiqL9nMSE2rUJtPzQyvqmDwO5bVZt3B+fTVdo4gxuiqw25A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/rpc": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-9.7.0.tgz",
-      "integrity": "sha512-VnZ4ABgQeoS4RwofcePkDP7L6tf3Kh5D7LQKoyRM4R6XtfSsYefym6XKaRl3saGtthH5YyjgNJ0Tgdjen4wAAw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.0.0.tgz",
+      "integrity": "sha512-QrpOZMwz2pAjvl6Hky2PauYoMpLCASn3osjn7uKUbgFV70sahyj6tmx4rRgRX7vHu2WQLZev+YsuO4EujiBDOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.7.0.tgz",
-      "integrity": "sha512-5xbvDASjklrmy88O6gmGXgYhpByCXqOj5wIgyvwZe2l83T1bE+iOfGI4pGzZJ/mN+qTn1DNKq8BPBPtDgb7Q2Q==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.0.0.tgz",
+      "integrity": "sha512-JRsato0s2IjYdsng+AGL6oAqgZVQgih5aWKdmxs21H6EdhMaoFDmRE5kXm/RT5a6OMdtnzQM9DqeToqBChWIOQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.7.0.tgz",
-      "integrity": "sha512-ZaaBr0pTvNxmyUbIn+nVPXPr383VqJzfUDMWicgTjJIeo2+T2hOq2kNpgpvTIrWtZrsZnSP8oXms1+sKTjcvkw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.0.0.tgz",
+      "integrity": "sha512-q+0pHQ8DbqjemyaOn/mTtBRbCuKDqhnsVbZ6J9zkTsxPgMpccjy0s5oLXwomfrrxMRBH+UcbERwtUmE+SbnoIQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {
@@ -4012,9 +4029,9 @@
       }
     },
     "node_modules/@docusaurus/babel": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.0.tgz",
-      "integrity": "sha512-mqCJhCZNZUDg0zgDEaPTM4DnRsisa24HdqTy/qn/MQlbwhTb4WVaZg6ZyX6yIVKqTz8fS1hBMgM+98z+BeJJDg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.1.tgz",
+      "integrity": "sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -4026,8 +4043,8 @@
         "@babel/preset-typescript": "^7.25.9",
         "@babel/runtime": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -4037,17 +4054,17 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.0.tgz",
-      "integrity": "sha512-iONUGZGgp+lAkw/cJZH6irONcF4p8+278IsdRlq8lYhxGjkoNUs0w7F4gVXBYSNChq5KG5/JleTSsdJySShxow==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.1.tgz",
+      "integrity": "sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.10.0",
-        "@docusaurus/cssnano-preset": "3.10.0",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/babel": "3.10.1",
+        "@docusaurus/cssnano-preset": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -4065,7 +4082,7 @@
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
         "webpack": "^5.95.0",
-        "webpackbar": "^6.0.1"
+        "webpackbar": "^7.0.0"
       },
       "engines": {
         "node": ">=20.0"
@@ -4080,18 +4097,18 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.0.tgz",
-      "integrity": "sha512-mgLdQsO8xppnQZc3LPi+Mf+PkPeyxJeIx11AXAq/14fsaMefInQiMEZUUmrc7J+956G/f7MwE7tn8KZgi3iRcA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
+      "integrity": "sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.10.0",
-        "@docusaurus/bundler": "3.10.0",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/mdx-loader": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/babel": "3.10.1",
+        "@docusaurus/bundler": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -4147,9 +4164,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.0.tgz",
-      "integrity": "sha512-qzSshTO1DB3TYW+dPUal5KHM7XPc5YQfzF3Kdb2NDACJUyGbNcFtw3tGkCJlYwhNCRKbZcmwraKUS1i5dcHdGg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.1.tgz",
+      "integrity": "sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -4162,9 +4179,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.0.tgz",
-      "integrity": "sha512-9jrZzFuBH1LDRlZ7cznAhCLmAZ3HSDqgwdrSSZdGHq9SPUOQgXXu8mnxe2ZRB9NS1PCpMTIOVUqDtZPIhMafZg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
+      "integrity": "sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -4175,14 +4192,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.0.tgz",
-      "integrity": "sha512-mQQV97080AH4PYNs087l202NMDqRopZA4mg5W76ZZyTFrmWhJ3mHg+8A+drJVENxw5/Q+wHMHLgsx+9z1nEs0A==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.1.tgz",
+      "integrity": "sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -4214,12 +4231,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.0.tgz",
-      "integrity": "sha512-/1O0Zg8w3DFrYX/I6Fbss7OJrtZw1QoyjDhegiFNHVi9A9Y0gQ3jUAytVxF6ywpAWpLyLxch8nN8H/V3XfzdJQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
+      "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.10.0",
+        "@docusaurus/types": "3.10.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -4233,19 +4250,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.0.tgz",
-      "integrity": "sha512-RuTz68DhB7CL96QO5UsFbciD7GPYq6QV+YMfF9V0+N4ZgLhJIBgpVAr8GobrKF6NRe5cyWWETU5z5T834piG9g==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz",
+      "integrity": "sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/mdx-loader": "3.10.0",
-        "@docusaurus/theme-common": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "cheerio": "1.0.0-rc.12",
         "combine-promises": "^1.1.0",
         "feed": "^4.2.2",
@@ -4268,21 +4285,21 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.0.tgz",
-      "integrity": "sha512-9BjHhf15ct8Z7TThTC0xRndKDVvMKmVsAGAN7W9FpNRzfMdScOGcXtLmcCWtJGvAezjOJIm6CxOYCy3Io5+RnQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
+      "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/mdx-loader": "3.10.0",
-        "@docusaurus/module-type-aliases": "3.10.0",
-        "@docusaurus/theme-common": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -4302,16 +4319,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.0.tgz",
-      "integrity": "sha512-5amX8kEJI+nIGtuLVjYk59Y5utEJ3CHETFOPEE4cooIRLA4xM4iBsA6zFgu4ljcopeYwvBzFEWf5g2I6Yb9SkA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz",
+      "integrity": "sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/mdx-loader": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -4325,15 +4342,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.0.tgz",
-      "integrity": "sha512-6q1vtt5FJcg5osgkHeM1euErECNqEZ5Z1j69yiNx2luEBIso+nxCkS9nqj8w+MK5X7rvKEToGhFfOFWncs51pQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz",
+      "integrity": "sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4341,14 +4358,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.0.tgz",
-      "integrity": "sha512-XcljKN+G+nmmK69uQA1d9BlYU3ZftG3T3zpK8/7Hf/wrOlV7TA4Ampdrdwkg0jElKdKAoSnPhCO0/U3bQGsVQQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.1.tgz",
+      "integrity": "sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
@@ -4362,14 +4379,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.0.tgz",
-      "integrity": "sha512-hTEoodatpBZnUat5nFExbuTGA1lhWGy7vZGuTew5Q3QDtGKFpSJLYmZJhdTjvCFwv1+qQ67hgAVlKdJOB8TXow==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz",
+      "integrity": "sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4381,14 +4398,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.0.tgz",
-      "integrity": "sha512-iB/Zzjv/eelJRbdULZqzWCbgMgJ7ht4ONVjXtN3+BI/muil6S87gQ1OJyPwlXD+ELdKkitC7bWv5eJdYOZLhrQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.1.tgz",
+      "integrity": "sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@types/gtag.js": "^0.0.20",
         "tslib": "^2.6.0"
       },
@@ -4401,14 +4418,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.0.tgz",
-      "integrity": "sha512-FEjZxqKgLHa+Wez/EgKxRwvArNCWIScfyEQD95rot7jkxp6nonjI5XIbGfO/iYhM5Qinwe8aIEQHP2KZtpqVuA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz",
+      "integrity": "sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4420,17 +4437,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.0.tgz",
-      "integrity": "sha512-DVTSLjB97hIjmayGnGcBfognCeI7ZuUKgEnU7Oz81JYqXtVg94mVTthDjq3QHTylYNeCUbkaW8VF0FDLcc8pPw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz",
+      "integrity": "sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -4444,15 +4461,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.0.tgz",
-      "integrity": "sha512-lNljBESaETZqVBMPqkrGchr+UPT1eZzEPLmJhz8I76BxbjqgsUnRvrq6lQJ9sYjgmgX52KB7kkgczqd2yzoswQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz",
+      "integrity": "sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -4467,26 +4484,26 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.0.tgz",
-      "integrity": "sha512-kw/Ye02Hc6xP1OdTswy8yxQEHg0fdPpyWAQRxr5b2x3h7LlG2Zgbb5BDFROnXDDMpUxB7YejlocJIE5HIEfpNA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.1.tgz",
+      "integrity": "sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/plugin-content-blog": "3.10.0",
-        "@docusaurus/plugin-content-docs": "3.10.0",
-        "@docusaurus/plugin-content-pages": "3.10.0",
-        "@docusaurus/plugin-css-cascade-layers": "3.10.0",
-        "@docusaurus/plugin-debug": "3.10.0",
-        "@docusaurus/plugin-google-analytics": "3.10.0",
-        "@docusaurus/plugin-google-gtag": "3.10.0",
-        "@docusaurus/plugin-google-tag-manager": "3.10.0",
-        "@docusaurus/plugin-sitemap": "3.10.0",
-        "@docusaurus/plugin-svgr": "3.10.0",
-        "@docusaurus/theme-classic": "3.10.0",
-        "@docusaurus/theme-common": "3.10.0",
-        "@docusaurus/theme-search-algolia": "3.10.0",
-        "@docusaurus/types": "3.10.0"
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/plugin-content-blog": "3.10.1",
+        "@docusaurus/plugin-content-docs": "3.10.1",
+        "@docusaurus/plugin-content-pages": "3.10.1",
+        "@docusaurus/plugin-css-cascade-layers": "3.10.1",
+        "@docusaurus/plugin-debug": "3.10.1",
+        "@docusaurus/plugin-google-analytics": "3.10.1",
+        "@docusaurus/plugin-google-gtag": "3.10.1",
+        "@docusaurus/plugin-google-tag-manager": "3.10.1",
+        "@docusaurus/plugin-sitemap": "3.10.1",
+        "@docusaurus/plugin-svgr": "3.10.1",
+        "@docusaurus/theme-classic": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/theme-search-algolia": "3.10.1",
+        "@docusaurus/types": "3.10.1"
       },
       "engines": {
         "node": ">=20.0"
@@ -4497,24 +4514,24 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.0.tgz",
-      "integrity": "sha512-9msCAsRdN+UG+RwPwCFb0uKy4tGoPh5YfBozXeGUtIeAgsMdn6f3G/oY861luZ3t8S2ET8S9Y/1GnpJAGWytww==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.1.tgz",
+      "integrity": "sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/mdx-loader": "3.10.0",
-        "@docusaurus/module-type-aliases": "3.10.0",
-        "@docusaurus/plugin-content-blog": "3.10.0",
-        "@docusaurus/plugin-content-docs": "3.10.0",
-        "@docusaurus/plugin-content-pages": "3.10.0",
-        "@docusaurus/theme-common": "3.10.0",
-        "@docusaurus/theme-translations": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/plugin-content-blog": "3.10.1",
+        "@docusaurus/plugin-content-docs": "3.10.1",
+        "@docusaurus/plugin-content-pages": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/theme-translations": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -4538,15 +4555,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.0.tgz",
-      "integrity": "sha512-Dkp1YXKn16ByCJAdIjbDIOpVb4Z66MsVD694/ilX1vAAHaVEMrVsf/NPd9VgreyFx08rJ9GqV1MtzsbTcU73Kg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
+      "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.10.0",
-        "@docusaurus/module-type-aliases": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -4566,20 +4583,20 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.0.tgz",
-      "integrity": "sha512-f5FPKI08e3JRG63vR/o4qeuUVHUHzFzM0nnF+AkB67soAZgNsKJRf2qmUZvlQkGwlV+QFkKe4D0ANMh1jToU3g==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz",
+      "integrity": "sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "^1.19.2",
         "@docsearch/react": "^3.9.0 || ^4.3.2",
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/plugin-content-docs": "3.10.0",
-        "@docusaurus/theme-common": "3.10.0",
-        "@docusaurus/theme-translations": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/plugin-content-docs": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/theme-translations": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "algoliasearch": "^5.37.0",
         "algoliasearch-helper": "^3.26.0",
         "clsx": "^2.0.0",
@@ -4598,9 +4615,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.0.tgz",
-      "integrity": "sha512-L9IbFLwTc5+XdgH45iQYufLn0SVZd6BUNelDbKIFlH+E4hhjuj/XHWAFMX/w2K59rfy8wak9McOaei7BSUfRPA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.1.tgz",
+      "integrity": "sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -4611,9 +4628,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-      "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4647,14 +4664,14 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.0.tgz",
-      "integrity": "sha512-T3B0WTigsIthe0D4LQa2k+7bJY+c3WS+Wq2JhcznOSpn1lSN64yNtHQXboCj3QnUs1EuAZszQG1SHKu5w5ZrlA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.1.tgz",
+      "integrity": "sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
         "escape-string-regexp": "^4.0.0",
         "execa": "^5.1.1",
         "file-loader": "^6.2.0",
@@ -4679,12 +4696,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.0.tgz",
-      "integrity": "sha512-JyL7sb9QVDgYvudIS81Dv0lsWm7le0vGZSDwsztxWam1SPBqrnkvBy9UYL/amh6pbybkyYTd3CMTkO24oMlCSw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.1.tgz",
+      "integrity": "sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.10.0",
+        "@docusaurus/types": "3.10.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4692,14 +4709,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.0.tgz",
-      "integrity": "sha512-c+6n2+ZPOJtWWc8Bb/EYdpSDfjYEScdCu9fB/SNjOmSCf1IdVnGf2T53o0tsz0gDRtCL90tifTL0JE/oMuP1Mw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
+      "integrity": "sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -6980,33 +6997,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -7044,6 +7034,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
+      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/anymatch": {
@@ -7923,23 +7922,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/clear-module": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
-      "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^2.0.0",
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
@@ -8091,14 +8073,13 @@
       }
     },
     "node_modules/comment-json": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.5.1.tgz",
-      "integrity": "sha512-taEtr3ozUmOB7it68Jll7s0Pwm+aoiHyXKrEC8SEodL4rNpdfDLqa7PfBlrgFoCNNdR8ImL+muti5IGvktJAAg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.6.2.tgz",
+      "integrity": "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
-        "core-util-is": "^1.0.3",
         "esprima": "^4.0.1"
       },
       "engines": {
@@ -8449,31 +8430,31 @@
       }
     },
     "node_modules/cspell": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.7.0.tgz",
-      "integrity": "sha512-ftxOnkd+scAI7RZ1/ksgBZRr0ouC7QRKtPQhD/PbLTKwAM62sSvRhE1bFsuW3VKBn/GilWzTjkJ40WmnDqH5iQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.0.0.tgz",
+      "integrity": "sha512-R25gsSR1SLlcGyw48fwJwp0PjXrVdl7RDO/Dm5+s4DvC1uQSlyiUxsr/8ZtbyC/MPeUJFQN9B4luqLlSm0WelQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "9.7.0",
-        "@cspell/cspell-performance-monitor": "9.7.0",
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-types": "9.7.0",
-        "@cspell/cspell-worker": "9.7.0",
-        "@cspell/dynamic-import": "9.7.0",
-        "@cspell/url": "9.7.0",
+        "@cspell/cspell-json-reporter": "10.0.0",
+        "@cspell/cspell-performance-monitor": "10.0.0",
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-types": "10.0.0",
+        "@cspell/cspell-worker": "10.0.0",
+        "@cspell/dynamic-import": "10.0.0",
+        "@cspell/url": "10.0.0",
         "ansi-regex": "^6.2.2",
         "chalk": "^5.6.2",
         "chalk-template": "^1.1.2",
         "commander": "^14.0.3",
-        "cspell-config-lib": "9.7.0",
-        "cspell-dictionary": "9.7.0",
-        "cspell-gitignore": "9.7.0",
-        "cspell-glob": "9.7.0",
-        "cspell-io": "9.7.0",
-        "cspell-lib": "9.7.0",
+        "cspell-config-lib": "10.0.0",
+        "cspell-dictionary": "10.0.0",
+        "cspell-gitignore": "10.0.0",
+        "cspell-glob": "10.0.0",
+        "cspell-io": "10.0.0",
+        "cspell-lib": "10.0.0",
         "fast-json-stable-stringify": "^2.1.0",
-        "flatted": "^3.3.3",
+        "flatted": "^3.4.2",
         "semver": "^7.7.4",
         "tinyglobby": "^0.2.15"
       },
@@ -8482,155 +8463,167 @@
         "cspell-esm": "bin.mjs"
       },
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.7.0.tgz",
-      "integrity": "sha512-pguh8A3+bSJ1OOrKCiQan8bvaaY125de76OEFz7q1Pq309lIcDrkoL/W4aYbso/NjrXaIw6OjkgPMGRBI/IgGg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.0.0.tgz",
+      "integrity": "sha512-HWK7SRnJ3N/kOThw/uzmXmQYCzBxu58Jkq2hHyte1voDl118BeNFoaNRWMpYdHbBi3kCj8gaZu8wGtm+Zmdhxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.7.0",
-        "comment-json": "^4.5.1",
-        "smol-toml": "^1.6.0",
-        "yaml": "^2.8.2"
+        "@cspell/cspell-types": "10.0.0",
+        "comment-json": "^4.6.2",
+        "smol-toml": "^1.6.1",
+        "yaml": "^2.8.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.7.0.tgz",
-      "integrity": "sha512-k/Wz0so32+0QEqQe21V9m4BNXM5ZN6lz3Ix/jLCbMxFIPl6wT711ftjOWIEMFhvUOP0TWXsbzcuE9mKtS5mTig==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.0.0.tgz",
+      "integrity": "sha512-KubSoEAJO+77KPSSWjoLCz0+MIWVNq3joGTSyxucAZrBSJD64Y1O4BHHr1aj6XHIZwXhWWNScQlrQR3OcIulng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-performance-monitor": "9.7.0",
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-types": "9.7.0",
-        "cspell-trie-lib": "9.7.0",
+        "@cspell/cspell-performance-monitor": "10.0.0",
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-types": "10.0.0",
+        "cspell-trie-lib": "10.0.0",
         "fast-equals": "^6.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.7.0.tgz",
-      "integrity": "sha512-MtoYuH4ah4K6RrmaF834npMcRsTKw0658mC6yvmBacUQOmwB/olqyuxF3fxtbb55HDb7cXDQ35t1XuwwGEQeZw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.0.0.tgz",
+      "integrity": "sha512-55XLH9Y52eR7QgyV28Uaw8V9cN1YZ3PQIyrN9YBR4ndQNBKJxO9+jX1nwSspwnccCZiE/N+GGxFzRBb75JDSCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.7.0",
-        "cspell-glob": "9.7.0",
-        "cspell-io": "9.7.0"
+        "@cspell/url": "10.0.0",
+        "cspell-glob": "10.0.0",
+        "cspell-io": "10.0.0"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-glob": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.7.0.tgz",
-      "integrity": "sha512-LUeAoEsoCJ+7E3TnUmWBscpVQOmdwBejMlFn0JkXy6LQzxrybxXBKf65RSdIv1o5QtrhQIMa358xXYQG0sv/tA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.0.0.tgz",
+      "integrity": "sha512-bXS35fMcA9X7GEkfnWBfoPd/vTnxxfXW+YHt6tWxu5fejfs00qUbjWp1oLC9FxRaXWxIkfsYp2mi1k1jYl4RVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.7.0",
-        "picomatch": "^4.0.3"
+        "@cspell/url": "10.0.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.7.0.tgz",
-      "integrity": "sha512-oEYME+7MJztfVY1C06aGcJgEYyqBS/v/ETkQGPzf/c6ObSAPRcUbVtsXZgnR72Gru9aBckc70xJcD6bELdoWCA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.0.0.tgz",
+      "integrity": "sha512-49udtYzkcCYEIDJbFOb4IwiAJebOYZnYvG6o6Ep19Tq0Xwjk7i4vxUprNiFNDCWFbcbJRPE9cpwQUVwp5WFGLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-types": "9.7.0"
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-types": "10.0.0"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-io": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.7.0.tgz",
-      "integrity": "sha512-V7x0JHAUCcJPRCH8c0MQkkaKmZD2yotxVyrNEx2SZTpvnKrYscLEnUUTWnGJIIf9znzISqw116PLnYu2c+zd6Q==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.0.0.tgz",
+      "integrity": "sha512-NQCAUhx9DwKApxPuFl7EK1K1XSaQEAPld45yjjwv93xF8rJkEGkgzOwjbqafwAD20eKYv1a7oj/9EC0S5jETSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "9.7.0",
-        "@cspell/url": "9.7.0"
+        "@cspell/cspell-service-bus": "10.0.0",
+        "@cspell/url": "10.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.7.0.tgz",
-      "integrity": "sha512-aTx/aLRpnuY1RJnYAu+A8PXfm1oIUdvAQ4W9E66bTgp1LWI+2G2++UtaPxRIgI0olxE9vcXqUnKpjOpO+5W9bQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.0.0.tgz",
+      "integrity": "sha512-PowW6JEjuv/F2aFEirZvBxpzHdchOnpsUJbeIcFcai0++taLTbHQObROBEBf7e0S8DnHpVD5TZkqrTME5e44wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "9.7.0",
-        "@cspell/cspell-performance-monitor": "9.7.0",
-        "@cspell/cspell-pipe": "9.7.0",
-        "@cspell/cspell-resolver": "9.7.0",
-        "@cspell/cspell-types": "9.7.0",
-        "@cspell/dynamic-import": "9.7.0",
-        "@cspell/filetypes": "9.7.0",
-        "@cspell/rpc": "9.7.0",
-        "@cspell/strong-weak-map": "9.7.0",
-        "@cspell/url": "9.7.0",
-        "clear-module": "^4.1.2",
-        "cspell-config-lib": "9.7.0",
-        "cspell-dictionary": "9.7.0",
-        "cspell-glob": "9.7.0",
-        "cspell-grammar": "9.7.0",
-        "cspell-io": "9.7.0",
-        "cspell-trie-lib": "9.7.0",
+        "@cspell/cspell-bundled-dicts": "10.0.0",
+        "@cspell/cspell-performance-monitor": "10.0.0",
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-resolver": "10.0.0",
+        "@cspell/cspell-types": "10.0.0",
+        "@cspell/dynamic-import": "10.0.0",
+        "@cspell/filetypes": "10.0.0",
+        "@cspell/rpc": "10.0.0",
+        "@cspell/strong-weak-map": "10.0.0",
+        "@cspell/url": "10.0.0",
+        "cspell-config-lib": "10.0.0",
+        "cspell-dictionary": "10.0.0",
+        "cspell-glob": "10.0.0",
+        "cspell-grammar": "10.0.0",
+        "cspell-io": "10.0.0",
+        "cspell-trie-lib": "10.0.0",
         "env-paths": "^4.0.0",
         "gensequence": "^8.0.8",
-        "import-fresh": "^3.3.1",
+        "import-fresh": "^4.0.0",
         "resolve-from": "^5.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-uri": "^3.1.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
-    "node_modules/cspell-trie-lib": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.7.0.tgz",
-      "integrity": "sha512-a2YqmcraL3g6I/4gY7SYWEZfP73oLluUtxO7wxompk/kOG2K1FUXyQfZXaaR7HxVv10axT1+NrjhOmXpfbI6LA==",
+    "node_modules/cspell-lib/node_modules/import-fresh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-4.0.0.tgz",
+      "integrity": "sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.15"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cspell-trie-lib": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.0.0.tgz",
+      "integrity": "sha512-R8qrMx10E/bm3Lecslwxn9XYo5NzSRK1rtandEX5n9UmEYHoBXjZELkg5+TOnV8VgrVaJSK57XtcGrbKp/4kSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "@cspell/cspell-types": "9.7.0"
+        "@cspell/cspell-types": "10.0.0"
       }
     },
     "node_modules/cspell/node_modules/chalk": {
@@ -10164,30 +10157,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/file-loader": {
@@ -14939,9 +14908,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -15333,19 +15302,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/parent-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
-      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -15581,9 +15537,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -18052,15 +18008,6 @@
         "entities": "^2.0.0"
       }
     },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -19960,12 +19907,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/value-equal": {
@@ -20390,75 +20341,30 @@
       }
     },
     "node_modules/webpackbar": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-6.0.1.tgz",
-      "integrity": "sha512-TnErZpmuKdwWBdMoexjio3KKX6ZtoKHRVvLIU0A47R0VVBDtx3ZyOJDktgYixhoJokZTYTt1Z37OkO9pnGJa9Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-7.0.0.tgz",
+      "integrity": "sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==",
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
+        "ansis": "^3.2.0",
         "consola": "^3.2.3",
-        "figures": "^3.2.0",
-        "markdown-table": "^2.0.0",
         "pretty-time": "^1.1.0",
-        "std-env": "^3.7.0",
-        "wrap-ansi": "^7.0.0"
+        "std-env": "^3.7.0"
       },
       "engines": {
         "node": ">=14.21.3"
       },
       "peerDependencies": {
+        "@rspack/core": "*",
         "webpack": "3 || 4 || 5"
-      }
-    },
-    "node_modules/webpackbar/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/webpackbar/node_modules/markdown-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-      "license": "MIT",
-      "dependencies": {
-        "repeat-string": "^1.0.0"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/webpackbar/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpackbar/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/websocket-driver": {
@@ -20676,9 +20582,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,9 @@
       "name": "stacks",
       "version": "0.0.0",
       "dependencies": {
-        "@analytics/google-analytics": "^1.1.0",
         "@docsearch/react": "^4.6.3",
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/mdx-loader": "^3.10.1",
-        "@docusaurus/plugin-google-analytics": "^3.10.1",
         "@docusaurus/plugin-google-gtag": "3.10.1",
         "@docusaurus/plugin-sitemap": "3.10.1",
         "@docusaurus/preset-classic": "3.10.1",
@@ -270,12 +268,6 @@
       "engines": {
         "node": ">= 14.0.0"
       }
-    },
-    "node_modules/@analytics/google-analytics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@analytics/google-analytics/-/google-analytics-1.1.0.tgz",
-      "integrity": "sha512-i8uGyELMtwEUAf3GNWNLNBzhRvReDn1RUxvMdMhjUA7+GNGxPOM4kkzFfv3giQXKNxTEjfsh75kqNcscbJsuaA==",
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,9 @@
     "markdownlint-cli": "^0.48.0"
   },
   "dependencies": {
-    "@analytics/google-analytics": "^1.1.0",
     "@docsearch/react": "^4.6.3",
     "@docusaurus/core": "^3.10.1",
     "@docusaurus/mdx-loader": "^3.10.1",
-    "@docusaurus/plugin-google-analytics": "^3.10.1",
     "@docusaurus/plugin-google-gtag": "3.10.1",
     "@docusaurus/plugin-sitemap": "3.10.1",
     "@docusaurus/preset-classic": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@docsearch/react": "^4.6.3",
-    "@docusaurus/core": "^3.10.1",
-    "@docusaurus/mdx-loader": "^3.10.1",
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/mdx-loader": "3.10.1",
     "@docusaurus/plugin-google-gtag": "3.10.1",
     "@docusaurus/plugin-sitemap": "3.10.1",
     "@docusaurus/preset-classic": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -16,20 +16,20 @@
     "validate": "node_modules/.bin/markdownlint ./docs --fix"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.10.0",
-    "cspell": "^9.7.0",
+    "@docusaurus/module-type-aliases": "3.10.1",
+    "cspell": "^10.0.0",
     "markdownlint": "^0.40.0",
     "markdownlint-cli": "^0.48.0"
   },
   "dependencies": {
     "@analytics/google-analytics": "^1.1.0",
     "@docsearch/react": "^4.6.3",
-    "@docusaurus/core": "3.10.0",
-    "@docusaurus/mdx-loader": "3.10.0",
-    "@docusaurus/plugin-google-analytics": "3.10.0",
-    "@docusaurus/plugin-google-gtag": "3.10.0",
-    "@docusaurus/plugin-sitemap": "3.10.0",
-    "@docusaurus/preset-classic": "3.10.0",
+    "@docusaurus/core": "^3.10.1",
+    "@docusaurus/mdx-loader": "^3.10.1",
+    "@docusaurus/plugin-google-analytics": "^3.10.1",
+    "@docusaurus/plugin-google-gtag": "3.10.1",
+    "@docusaurus/plugin-sitemap": "3.10.1",
+    "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "dotenv": "^17.4.2",
@@ -41,6 +41,7 @@
     "remark-images": "^4.1.0"
   },
   "overrides": {
+    "uuid": "14.0.0",
     "picomatch": "^4.0.4",
     "serialize-javascript": "^7.0.5",
     "smol-toml": "^1.6.1",


### PR DESCRIPTION
#### 📲 What

Disable analytics during local `docusaurus start` runs and remove unused direct legacy analytics dependencies.

#### 🤔 Why

Recent dependency upgrades exposed a dev-mode routing regression where internal navigation triggered `window.ga is not a function` and then `window.gtag is not a function`. This blocked exploratory testing and made local development unstable.

#### 🛠 How

- Removed the legacy `googleAnalytics` preset config.
- Added command-based gating so `gtag` is only enabled for `build` and `deploy`, not `start`.
- Removed unused direct dependencies `@analytics/google-analytics` and `@docusaurus/plugin-google-analytics`.
- Refreshed `package-lock.json`.

Backout plan:
Revert commit `3c5f32328` to restore the previous analytics configuration and dependency declarations.

#### 👀 Evidence

- `npm run build` passes.
- `npm run lint && npm run lint:spell` passes.
- Fresh dev-server exploratory test passes for `/` -> `/docs` -> `/docs/contributions` without runtime analytics errors.
- Production build still renders and builds successfully after the dependency cleanup.

#### 🕵️ How to test

- Run `npm start` and navigate from the homepage to `Documentation`, then to `New Contributions`.
- Confirm there is no `window.ga` or `window.gtag` runtime overlay.
- Run `npm run build`.
- Optionally run `npm run lint && npm run lint:spell`.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
